### PR TITLE
Media Message Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,4 @@ MigrationBackup/
 # Project-specific files
 *.swp
 default.ini
+storage/

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Note that this software is currently under development, and I am not responsible
 
 ## Milestones
 
-* ~~relay text messages from a Matrix room to an Urbit chat~~ **COMPLETE** [you are here]
-* relay text messages from a Matrix room to an Urbit chat
+* ~~relay text messages from a Matrix room to an Urbit chat~~ **COMPLETE**
+* relay text messages from an Urbit chat to a Matrix room
 * autojoin/autoconfig Matrix rooms when bot is invited
 * relay image messages from an Urbit chat to Matrix
-* relay image messages from Matrix to an Urbit chat
+* ~~relay image messages from Matrix to an Urbit chat~~ **COMPLETE**
 * provide configuration for displaying of reactions, replies, read receipts, typing notifications from Matrix to Urbit
 * provide commands for viewing Matrix room & user metadata
 
@@ -20,7 +20,9 @@ Note that this software is currently under development, and I am not responsible
 
 * Quinnat
 * matrix-nio
+* Boto3
 * an Urbit identity
+* an Urbit-compatible S3 bucket
 
 ## Setup
 
@@ -31,6 +33,10 @@ Install Quinnat via `pip`:
 Install matrix-nio via `pip`:
 
 `pip3 install matrix-nio`
+
+Install boto3 via `pip`:
+
+`pip3 install boto3`
 
 Set up a group on your Urbit for your bridge to reside in.
 

--- a/example.ini
+++ b/example.ini
@@ -1,3 +1,9 @@
+[S3]
+s3Url=http://127.0.0.1
+s3AccessKey=aaa
+s3SecretKey=aaa
+s3Bucket=aaa
+
 [MATRIX]
 matrixRoom = !matrixRoom:example.org
 matrixBotUser = @urbot:example.org

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 import configparser, quinnat, asyncio, boto3, requests, os
-from nio import Api, AsyncClient, RoomMessageText, RoomMessageImage
+from nio import Api, AsyncClient, RoomMessageText, RoomMessageMedia
 
 config = configparser.ConfigParser()
 config.read('default.ini')
@@ -46,8 +46,8 @@ async def urbitListener(message, replier):
 async def matrixTextListener(room, event):
     urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"{room.user_name(event.sender)} in {room.display_name}: {event.body}"})
 
-async def matrixImageListener(room, event):
-    urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"{room.user_name(event.sender)} in {room.display_name} posted an image:"})
+async def matrixMediaListener(room, event):
+    urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"{room.user_name(event.sender)} in {room.display_name} sent media:"})
 
     mxcSplit = event.url.split('/')
     imageDownloadRequest = requests.get(matrixHomeServer + Api.download(mxcSplit[2], mxcSplit[3])[1])
@@ -66,7 +66,7 @@ async def main():
     matrixClient = AsyncClient(matrixHomeServer, matrixBotUser)
     print(await matrixClient.login(matrixBotPass))
     matrixClient.add_event_callback(matrixTextListener, RoomMessageText)
-    matrixClient.add_event_callback(matrixImageListener, RoomMessageImage)
+    matrixClient.add_event_callback(matrixMediaListener, RoomMessageMedia)
 
     await matrixClient.sync_forever(timeout=30000)
 

--- a/main.py
+++ b/main.py
@@ -1,8 +1,13 @@
-import configparser, quinnat, asyncio
-from nio import AsyncClient, RoomMessageText
+import configparser, quinnat, asyncio, boto3, requests, os
+from nio import Api, AsyncClient, RoomMessageText, RoomMessageImage
 
 config = configparser.ConfigParser()
 config.read('default.ini')
+
+s3Url = config['S3']['s3Url']
+s3AccessKey = config['S3']['s3AccessKey']
+s3SecretKey = config['S3']['s3SecretKey']
+s3Bucket = config['S3']['s3Bucket']
 
 matrixRoom = config['MATRIX']['matrixRoom']
 matrixBotUser = config['MATRIX']['matrixBotUser']
@@ -14,6 +19,17 @@ urbitId = config['URBIT']['urbitId']
 urbitCode = config['URBIT']['urbitCode']
 urbitHost = config['URBIT']['urbitHost']
 urbitBridgeChat = config['URBIT']['urbitBridgeChat']
+
+if not os.path.exists('storage'):
+    os.makedirs('storage')
+
+s3Client = boto3.resource(
+    service_name='s3',
+    aws_access_key_id=s3AccessKey,
+    aws_secret_access_key=s3SecretKey,
+    endpoint_url=s3Url
+)
+s3BucketUrl = s3Url + '/' + s3Bucket
 
 urbitClient = quinnat.Quinnat(urbitUrl, urbitId, urbitCode)
 
@@ -27,15 +43,30 @@ async def urbitListener(message, replier):
             }
     )
 
-async def matrixListener(room, event):
-    urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"Got message from {room.user_name(event.sender)} in {room.display_name}: {event.body}"})
+async def matrixTextListener(room, event):
+    urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"{room.user_name(event.sender)} in {room.display_name}: {event.body}"})
+
+async def matrixImageListener(room, event):
+    urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"{room.user_name(event.sender)} in {room.display_name} posted an image:"})
+
+    mxcSplit = event.url.split('/')
+    imageDownloadRequest = requests.get(matrixHomeServer + Api.download(mxcSplit[2], mxcSplit[3])[1])
+    with open('storage/' + event.body, 'wb') as f:
+        f.write(imageDownloadRequest.content)
+    s3Client.Bucket(s3Bucket).upload_file(
+            Filename = 'storage/' + event.body,
+            Key = event.body
+    )
+    s3AttachmentUrl = s3BucketUrl + '/' + event.body
+    urbitClient.post_message(urbitHost, urbitBridgeChat, {"url": f"{s3AttachmentUrl}"})
 
 async def main():
     urbitClient.connect()
 
     matrixClient = AsyncClient(matrixHomeServer, matrixBotUser)
     print(await matrixClient.login(matrixBotPass))
-    matrixClient.add_event_callback(matrixListener, RoomMessageText)
+    matrixClient.add_event_callback(matrixTextListener, RoomMessageText)
+    matrixClient.add_event_callback(matrixImageListener, RoomMessageImage)
 
     await matrixClient.sync_forever(timeout=30000)
 


### PR DESCRIPTION
This PR adds support for relaying Matrix media messages to an S3 bucket, then posting the attachments' link to Urbit.

Media messages from encrypted Matrix rooms are not supported at this time.